### PR TITLE
Added matcher to allow proper date matching in unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.common</groupId>
       <artifactId>framework</artifactId>
+      <version>10.49.7-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.common</groupId>
       <artifactId>framework</artifactId>
-      <version>10.49.7-SNAPSHOT</version>
+      <version>10.49.8</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/common/matcher/DateMatcher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/matcher/DateMatcher.java
@@ -1,0 +1,44 @@
+package uk.gov.ons.ctp.common.matcher;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+
+public class DateMatcher extends BaseMatcher<Date> {
+
+    private static DateFormat DEFAULT_DATE_FORMAT = new MultiIsoDateFormat();
+
+    public DateMatcher(String date) throws ParseException {
+        this(DEFAULT_DATE_FORMAT.parse(date));
+    }
+
+    public DateMatcher(Date date){
+        this.date = date;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+        if (o instanceof String){
+            try {
+                return this.date.equals(DEFAULT_DATE_FORMAT.parse((String) o));
+            } catch (ParseException e) {
+                return false;
+            }
+        } else if (o instanceof Date){
+            return this.date.equals(o);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("The dates do not match");
+    }
+
+    private Date date;
+}


### PR DESCRIPTION
Previously many of the endpoint unit tests used string comparisons to compare dates.  This is obviously brittle as any difference in the format, timezone etc of the string will cause a failure even through the dates are actually the same.   This PR adds a DateMatcher that makes it possible to compare the dates in the unit tests instead of the strings