### PR TITLE
Add formatter and checkstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/ONSdigital/rm-common-service.svg?branch=master)](https://travis-ci.org/ONSdigital/rm-common-service)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/37fdebe43c0f467ead6394a3d43d90f4)](https://www.codacy.com/app/sdcplatform/rm-common-service?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/rm-common-service&amp;utm_campaign=Badge_Grade)
 
-# Common Test Framework 
+# Common Test Framework
 This repository contains common test framework code for the Response Management [Spring Boot](http://projects.spring.io/spring-boot/) applications.
 
 This project provides the base class for the ONS Spring Boot/Jersey unit tests, which provides a Domain-Specific Language (DSL) for unit testing RESTful endpoints.
@@ -11,5 +11,9 @@ This project provides the base class for the ONS Spring Boot/Jersey unit tests, 
 ```
 mvn --update-snapshots
 ```
+
+## Code Styler
+To use the code styler please goto this url (https://github.com/google/google-java-format) and follow the Intellij instructions or Eclipse depending on what you use
+
 ## Copyright
 Copyright (C) 2016 Crown Copyright (Office for National Statistics)

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.6</version>
+    <version>10.49.12</version>
   </parent>
 
   <dependencies>
@@ -59,6 +59,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
@@ -1,18 +1,13 @@
 package uk.gov.ons.ctp.common;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * Loads JSON representation of test DTOS for unit tests
- *
- */
+/** Loads JSON representation of test DTOS for unit tests */
 @Slf4j
 public class FixtureHelper {
 
@@ -22,8 +17,8 @@ public class FixtureHelper {
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the
-   *           calling class in the classpath?
+   * @throws Exception failed to load - does the json file exist alongside the calling class in the
+   *     classpath?
    */
   public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz) throws Exception {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
@@ -31,20 +26,19 @@ public class FixtureHelper {
   }
 
   /**
-   * Find, deserialize and return List of dummy test objects from a json file
-   * This method derives the path and file name of the json file by looking at
-   * the class and method that called it, as well as the name of the type you
-   * asked it to return.
+   * Find, deserialize and return List of dummy test objects from a json file This method derives
+   * the path and file name of the json file by looking at the class and method that called it, as
+   * well as the name of the type you asked it to return.
    *
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
-   * @param qualifier added to file name to allow a class to have multiple forms
-   *          of same type
+   * @param qualifier added to file name to allow a class to have multiple forms of same type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the
-   *           calling class in the classpath?
+   * @throws Exception failed to load - does the json file exist alongside the calling class in the
+   *     classpath?
    */
-  public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz, final String qualifier) throws Exception {
+  public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz, final String qualifier)
+      throws Exception {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     String callerMethodName = new Exception().getStackTrace()[1].getMethodName();
     return actuallyLoadFixtures(clazz, callerClassName, callerMethodName, qualifier);
@@ -56,8 +50,8 @@ public class FixtureHelper {
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the
-   *           calling class in the classpath?
+   * @throws Exception failed to load - does the json file exist alongside the calling class in the
+   *     classpath?
    */
   public static <T> List<T> loadClassFixtures(final Class<T[]> clazz) throws Exception {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
@@ -65,23 +59,21 @@ public class FixtureHelper {
   }
 
   /**
-   * Find, deserialize and return List of dummy test objects from a json file
-   * This method derives the path and file name of the json file by looking at
-   * the class and method that called it, as well as the name of the type you
-   * asked it to return.
+   * Find, deserialize and return List of dummy test objects from a json file This method derives
+   * the path and file name of the json file by looking at the class and method that called it, as
+   * well as the name of the type you asked it to return.
    *
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
-   * @param qualifier added to file name to allow a class to have multiple forms
-   *          of same type
+   * @param qualifier added to file name to allow a class to have multiple forms of same type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the
-   *           calling class in the classpath?
+   * @throws Exception failed to load - does the json file exist alongside the calling class in the
+   *     classpath?
    */
-  public static <T> List<T> loadClassFixtures(final Class<T[]> clazz, final String qualifier) throws Exception {
+  public static <T> List<T> loadClassFixtures(final Class<T[]> clazz, final String qualifier)
+      throws Exception {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadFixtures(clazz, callerClassName, null, qualifier);
-
   }
 
   /**
@@ -91,13 +83,16 @@ public class FixtureHelper {
    * @param <T> the type of object we expect to load and return a List of
    * @param callerClassName name of the class that made the initial call
    * @param callerMethodName name of the method that made the initial call
-   * @param qualifier added to file name to allow a class to have multiple forms
-   *          of same type
+   * @param qualifier added to file name to allow a class to have multiple forms of same type
    * @return the loaded dummies of the the type T in a List
    * @throws Exception summats went wrong
    */
-  private static <T> List<T> actuallyLoadFixtures(final Class<T[]> clazz, final String callerClassName,
-      final String callerMethodName, final String qualifier) throws Exception {
+  private static <T> List<T> actuallyLoadFixtures(
+      final Class<T[]> clazz,
+      final String callerClassName,
+      final String callerMethodName,
+      final String qualifier)
+      throws Exception {
     List<T> dummies = null;
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
@@ -119,16 +114,22 @@ public class FixtureHelper {
    *
    * @param callerClassName the name of the class that made the initial call
    * @param clazzName the type of object to deserialize and return in a List
-   * @param methodName the name of the method in the callerClass that made the
-   *          initial call
-   * @param qualifier further quaification is a single method may need to have
-   *          two collections of the same type, qualified
+   * @param methodName the name of the method in the callerClass that made the initial call
+   * @param qualifier further quaification is a single method may need to have two collections of
+   *     the same type, qualified
    * @return the constructed path string
    */
-  private static String generatePath(final String callerClassName, final String clazzName, final String methodName,
+  private static String generatePath(
+      final String callerClassName,
+      final String clazzName,
+      final String methodName,
       final String qualifier) {
-    return callerClassName.replaceAll("\\.", "/") + "." + ((methodName != null) ? (methodName + ".") : "") + clazzName
+    return callerClassName.replaceAll("\\.", "/")
         + "."
-        + ((qualifier != null) ? (qualifier + ".") : "") + "json";
+        + ((methodName != null) ? (methodName + ".") : "")
+        + clazzName
+        + "."
+        + ((qualifier != null) ? (qualifier + ".") : "")
+        + "json";
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/MvcHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/MvcHelper.java
@@ -1,59 +1,64 @@
 package uk.gov.ons.ctp.common;
 
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
-/**
- * MVC Helper
- */
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/** MVC Helper */
 public class MvcHelper {
 
-    /**
-     * Mock Http Servlet Request Builder
-     * @param url url to request
-     * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
-     */
-    public static MockHttpServletRequestBuilder getJson(String url) {
-        return get(url).accept(MediaType.APPLICATION_JSON);
-    }
+  /**
+   * Mock Http Servlet Request Builder
+   *
+   * @param url url to request
+   * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
+   */
+  public static MockHttpServletRequestBuilder getJson(String url) {
+    return get(url).accept(MediaType.APPLICATION_JSON);
+  }
 
-    /**
-     * Mock Http Servlet Request Builder
-     * @param url url to request
-     * @param content json content to post
-     * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
-     */
-    public static MockHttpServletRequestBuilder postJson(String url, String content) {
-        return post(url).content(content)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+  /**
+   * Mock Http Servlet Request Builder
+   *
+   * @param url url to request
+   * @param content json content to post
+   * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
+   */
+  public static MockHttpServletRequestBuilder postJson(String url, String content) {
+    return post(url)
+        .content(content)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON);
+  }
 
-    /**
-     * Mock Http Servlet Request Builder
-     * @param url url to request
-     * @param content json content
-     * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
-     */
-    public static MockHttpServletRequestBuilder putJson(String url, String content) {
-        return put(url).content(content)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+  /**
+   * Mock Http Servlet Request Builder
+   *
+   * @param url url to request
+   * @param content json content
+   * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
+   */
+  public static MockHttpServletRequestBuilder putJson(String url, String content) {
+    return put(url)
+        .content(content)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON);
+  }
 
-    /**
-     * Mock Http Servlet Request Builder
-     * @param url url to request
-     * @param content xml content
-     * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
-     */
-    public static MockHttpServletRequestBuilder postXml(String url, String content) {
-        return post(url).content(content)
-                .contentType(MediaType.TEXT_XML)
-                .accept(MediaType.APPLICATION_JSON);
-    }
+  /**
+   * Mock Http Servlet Request Builder
+   *
+   * @param url url to request
+   * @param content xml content
+   * @return MockHttpServletRequestBuilder Mock Http Servlet Request Builder
+   */
+  public static MockHttpServletRequestBuilder postXml(String url, String content) {
+    return post(url)
+        .content(content)
+        .contentType(MediaType.TEXT_XML)
+        .accept(MediaType.APPLICATION_JSON);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/TestHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/TestHelper.java
@@ -6,15 +6,12 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-/**
- * Some individual methods for unit tests to reuse
- *
- */
+/** Some individual methods for unit tests to reuse */
 public class TestHelper {
 
   /**
-   * Creates an instance of the target class, using its default constructor, and
-   * invokes the private method, passing the provided params.
+   * Creates an instance of the target class, using its default constructor, and invokes the private
+   * method, passing the provided params.
    *
    * @param target the Class owning the provate method
    * @param methodName the name of the private method we wish to invoke
@@ -22,10 +19,8 @@ public class TestHelper {
    * @return the object that came back from the method!
    * @throws Exception Something went wrong with reflection, Get over it.
    */
-  public static Object callPrivateMethodOfDefaultConstructableClass(final Class<?> target,
-      final String methodName,
-      final Object... params)
-      throws Exception {
+  public static Object callPrivateMethodOfDefaultConstructableClass(
+      final Class<?> target, final String methodName, final Object... params) throws Exception {
     Constructor<?> constructor = target.getConstructor();
     Object instance = constructor.newInstance();
     Class<?>[] parameterTypes = new Class[params.length];
@@ -39,6 +34,7 @@ public class TestHelper {
 
   /**
    * Creates and returns Test Date
+   *
    * @param date date to parse
    * @return String test date as String
    */
@@ -47,6 +43,5 @@ public class TestHelper {
     ZonedDateTime zdt = ZonedDateTime.parse(date, formatter);
     ZonedDateTime compareDate = zdt.withZoneSameInstant(ZoneOffset.systemDefault());
     return formatter.format(compareDate);
-
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/matcher/DateMatcher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/matcher/DateMatcher.java
@@ -1,44 +1,43 @@
 package uk.gov.ons.ctp.common.matcher;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import uk.gov.ons.ctp.common.util.MultiIsoDateFormat;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.util.Date;
-
 public class DateMatcher extends BaseMatcher<Date> {
 
-    private static DateFormat DEFAULT_DATE_FORMAT = new MultiIsoDateFormat();
+  private static DateFormat DEFAULT_DATE_FORMAT = new MultiIsoDateFormat();
 
-    public DateMatcher(String date) throws ParseException {
-        this(DEFAULT_DATE_FORMAT.parse(date));
+  public DateMatcher(String date) throws ParseException {
+    this(DEFAULT_DATE_FORMAT.parse(date));
+  }
+
+  public DateMatcher(Date date) {
+    this.date = date;
+  }
+
+  @Override
+  public boolean matches(Object o) {
+    if (o instanceof String) {
+      try {
+        return this.date.equals(DEFAULT_DATE_FORMAT.parse((String) o));
+      } catch (ParseException e) {
+        return false;
+      }
+    } else if (o instanceof Date) {
+      return this.date.equals(o);
+    } else {
+      return false;
     }
+  }
 
-    public DateMatcher(Date date){
-        this.date = date;
-    }
+  @Override
+  public void describeTo(Description description) {
+    description.appendText("The dates do not match");
+  }
 
-    @Override
-    public boolean matches(Object o) {
-        if (o instanceof String){
-            try {
-                return this.date.equals(DEFAULT_DATE_FORMAT.parse((String) o));
-            } catch (ParseException e) {
-                return false;
-            }
-        } else if (o instanceof Date){
-            return this.date.equals(o);
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public void describeTo(Description description) {
-        description.appendText("The dates do not match");
-    }
-
-    private Date date;
+  private Date date;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/utility/MockMvcControllerAdviceHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/utility/MockMvcControllerAdviceHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.common.utility;
 
+import java.lang.reflect.Method;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.web.method.HandlerMethod;
@@ -7,55 +8,56 @@ import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
 import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
 import org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod;
 
-import java.lang.reflect.Method;
-
-/**
- * Mock Mvc Controller Advice Helper
- */
+/** Mock Mvc Controller Advice Helper */
 public class MockMvcControllerAdviceHelper extends ExceptionHandlerExceptionResolver {
 
-    private final Class exceptionHandlerClass;
+  private final Class exceptionHandlerClass;
 
-    private static final String ERROR_MSG = "Unable to instantiate exception handler %s";
+  private static final String ERROR_MSG = "Unable to instantiate exception handler %s";
 
-    /**
-     * MockMvcControllerAdviceHelper constructor
-     * @param exceptionHandlerClass Exception Handler Class
-     */
-    public MockMvcControllerAdviceHelper(Class exceptionHandlerClass) {
-        super();
-        getMessageConverters().add(new MappingJackson2HttpMessageConverter());
-        getMessageConverters().add(new Jaxb2RootElementHttpMessageConverter());
-        this.exceptionHandlerClass = exceptionHandlerClass;
-        afterPropertiesSet();
+  /**
+   * MockMvcControllerAdviceHelper constructor
+   *
+   * @param exceptionHandlerClass Exception Handler Class
+   */
+  public MockMvcControllerAdviceHelper(Class exceptionHandlerClass) {
+    super();
+    getMessageConverters().add(new MappingJackson2HttpMessageConverter());
+    getMessageConverters().add(new Jaxb2RootElementHttpMessageConverter());
+    this.exceptionHandlerClass = exceptionHandlerClass;
+    afterPropertiesSet();
+  }
+
+  /**
+   * Default MockMvcControllerAdviceHelper Constructor
+   *
+   * @param exceptionHandlerClass Exception Handler Class
+   * @return MockMvcControllerAdviceHelper object
+   */
+  public static MockMvcControllerAdviceHelper mockAdviceFor(Class exceptionHandlerClass) {
+    return new MockMvcControllerAdviceHelper(exceptionHandlerClass);
+  }
+
+  /**
+   * Exception Handler getter
+   *
+   * @param handlerMethod HandlerMethod
+   * @param exception Exception
+   * @return ServletInvocableHandlerMethod containing new exceptionhandler and method.
+   */
+  protected ServletInvocableHandlerMethod getExceptionHandlerMethod(
+      HandlerMethod handlerMethod, Exception exception) {
+    Object exceptionHandler = null;
+
+    try {
+      exceptionHandler = exceptionHandlerClass.newInstance();
+    } catch (IllegalAccessException | InstantiationException e) {
+      throw new RuntimeException(
+          String.format(ERROR_MSG, exceptionHandlerClass.getCanonicalName()), e);
     }
 
-    /**
-     * Default MockMvcControllerAdviceHelper Constructor
-     * @param exceptionHandlerClass Exception Handler Class
-     * @return MockMvcControllerAdviceHelper object
-     */
-    public static MockMvcControllerAdviceHelper mockAdviceFor(Class exceptionHandlerClass) {
-        return new MockMvcControllerAdviceHelper(exceptionHandlerClass);
-    }
-
-    /**
-     * Exception Handler getter
-     * @param handlerMethod HandlerMethod
-     * @param exception Exception
-     * @return ServletInvocableHandlerMethod containing new exceptionhandler and method.
-     */
-    protected ServletInvocableHandlerMethod getExceptionHandlerMethod(HandlerMethod handlerMethod,
-                                                                      Exception exception) {
-        Object exceptionHandler = null;
-
-        try {
-            exceptionHandler = exceptionHandlerClass.newInstance();
-        } catch (IllegalAccessException | InstantiationException e) {
-            throw new RuntimeException(String.format(ERROR_MSG, exceptionHandlerClass.getCanonicalName()), e);
-        }
-
-        Method method = new ExceptionHandlerMethodResolver(exceptionHandlerClass).resolveMethod(exception);
-        return new ServletInvocableHandlerMethod(exceptionHandler, method);
-    }
+    Method method =
+        new ExceptionHandlerMethodResolver(exceptionHandlerClass).resolveMethod(exception);
+    return new ServletInvocableHandlerMethod(exceptionHandler, method);
+  }
 }


### PR DESCRIPTION
# Motivation and Context
Adding maven plugin to format the java code automatically on builds. The
style of the formatter is opinionated favouring googles formatting. The
benefit of this is it allows us to easily plugin in googles check style
file. The checkstyle.xml has been made more lenient to ignore things
like missing javadoc and abbreviations.

# What has changed
Inherit new checkstyle configuration from parent pom
Inerit formatting from parent pom
Travis to fail on invalid style or checkstyle

# How to test?
1. Checkout branch
1. Mess up format
1. Run mvn install
1. Check format is fixed

# Links
Formatter plugin: https://github.com/google/coveo/fmt-maven-plugin
Checkstyle plugin: https://github.com/google/checkstyle/checkstyle
Intellij formatter: https://github.com/google/google/google-java-format#intellij
Eclipse formatter: https://github.com/google/google-java-format#eclipse
