### PR TITLE
Reformatted Mapzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - curl ifconfig.co|xargs echo "Travis IP address is ";
 
 script:
-  - mvn test -B
+  - mvn fmt:check test -B
   # Only release on master builds
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     git config --global set user.email "travis@travis-ci.org";

--- a/src/main/java/uk/gov/ons/ctp/common/utility/Mapzer.java
+++ b/src/main/java/uk/gov/ons/ctp/common/utility/Mapzer.java
@@ -16,7 +16,7 @@ public class Mapzer {
   public Mapzer(ResourceLoader resourceLoader) {
     this.resourceLoader = resourceLoader;
   }
-  
+
   /**
    * Convert an object into its XML equivalent based on the provided schema
    *


### PR DESCRIPTION
# Motivation and Context
When travis attempted to build a release it failed because the formatter decided Mapzer.java had the wrong kind of blank line in it.  

# What has changed
Mapzer.java has been reformatted

# How to test?
- check out branch
- mvn clean install
- ensure that there are no local modifications

# Links
- [failed travis build](https://travis-ci.org/ONSdigital/rm-common-test-framework/jobs/401744514#L574)