### PR TITLE
Add unirest initialiser method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,6 @@
       <artifactId>unirest-java</artifactId>
       <version>1.4.9</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.5</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,16 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.mashape.unirest</groupId>
+      <artifactId>unirest-java</artifactId>
+      <version>1.4.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/ons/ctp/common/UnirestInitialiser.java
+++ b/src/main/java/uk/gov/ons/ctp/common/UnirestInitialiser.java
@@ -1,0 +1,20 @@
+package uk.gov.ons.ctp.common;
+
+import com.google.gson.Gson;
+import com.mashape.unirest.http.Unirest;
+
+public class UnirestInitialiser {
+  public static void initialise() {
+    final Gson gson = new Gson();
+    Unirest.setObjectMapper(
+        new com.mashape.unirest.http.ObjectMapper() {
+          public <T> T readValue(final String value, final Class<T> valueType) {
+            return gson.fromJson(value, valueType);
+          }
+
+          public String writeValue(final Object value) {
+            return gson.toJson(value);
+          }
+        });
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/UnirestInitialiser.java
+++ b/src/main/java/uk/gov/ons/ctp/common/UnirestInitialiser.java
@@ -1,19 +1,29 @@
 package uk.gov.ons.ctp.common;
 
-import com.google.gson.Gson;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mashape.unirest.http.Unirest;
 
+import java.io.IOException;
+
 public class UnirestInitialiser {
-  public static void initialise() {
-    final Gson gson = new Gson();
+  public static void initialise(final ObjectMapper mapper) {
     Unirest.setObjectMapper(
         new com.mashape.unirest.http.ObjectMapper() {
           public <T> T readValue(final String value, final Class<T> valueType) {
-            return gson.fromJson(value, valueType);
+            try {
+              return mapper.readValue(value, valueType);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
           }
 
           public String writeValue(final Object value) {
-            return gson.toJson(value);
+            try {
+              return mapper.writeValueAsString(value);
+            } catch (JsonProcessingException e) {
+              throw new RuntimeException(e);
+            }
           }
         });
   }


### PR DESCRIPTION
# Motivation and Context
Add a method to initialise unirest with a objectmapper/serialiser to
prevent every test having to define this method

# What has changed
Add initialiser for Unirest

# How to test?
Manually test by adding this to the class with the survey service running (Awkward to unit test and consuming tests will fail if broken)
```
  public static void main(String[] args) throws UnirestException {
    initialise();
    HttpResponse<List> mapHttpResponse = Unirest.get("http://localhost:8080/surveys").basicAuth("admin", "secret").asObject(List.class);
    System.out.println(mapHttpResponse.getBody());
  }
```

# Links
https://github.com/ONSdigital/rm-action-service/pull/61
